### PR TITLE
[dev_fit_openRipple]修复点击高亮接口两端差异，iOS存在将关闭了用户交互的控件交互打开的问题

### DIFF
--- a/MLN-iOS/MLN/Classes/Kit/Category/UIView+MLNKit.m
+++ b/MLN-iOS/MLN/Classes/Kit/Category/UIView+MLNKit.m
@@ -1094,9 +1094,6 @@ static const void *kLuaOnDetachedFromWindowCallback = &kLuaOnDetachedFromWindowC
 //开启高亮
 - (void)lua_openRipple:(BOOL)open
 {
-    if (!self.userInteractionEnabled && open) {
-        self.userInteractionEnabled = YES;
-    }
     [self openRipple:open];
 }
 


### PR DESCRIPTION
删除开启高亮时，对用户交互的修改