### PR TITLE
fix:修复ViewPager修改尺寸后，容器CollectionView未同步修改的问题

### DIFF
--- a/MLN-iOS/MLN/Classes/Kit/Component/UI/ViewPager/MLNViewPager.m
+++ b/MLN-iOS/MLN/Classes/Kit/Component/UI/ViewPager/MLNViewPager.m
@@ -697,6 +697,12 @@
     [self invalidateTimer];
 }
 
+- (void)lua_changedLayout
+{
+    [super lua_changedLayout];
+    [self setupMainViewFrame];
+}
+
 LUA_EXPORT_VIEW_BEGIN(MLNViewPager)
 LUA_EXPORT_VIEW_PROPERTY(adapter, "setAdapter:","adapter", MLNViewPager)
 LUA_EXPORT_VIEW_PROPERTY(autoScroll, "setAutoScroll:", "autoScroll", MLNViewPager)


### PR DESCRIPTION
当ViewPager尺寸计算结束后，需要同步设置mainView的尺寸